### PR TITLE
Docker updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-node_modules
-npm-debug.log
-Dockerfile
-dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
-FROM node:alpine as controllerbuild
+FROM node:12-alpine AS build
 RUN apk add --no-cache make gcc g++ python linux-headers udev tzdata
 WORKDIR /app
-COPY package*.json ./
+COPY defaultConfig.json package.json ./
 RUN npm install
 COPY . .
-RUN npm run build-prod
+RUN npm run build && npm prune --production
 
-FROM node:alpine as releasecontainer
+FROM node:12-alpine as prod
 RUN mkdir /app && chown node:node /app
-COPY --chown=node:node --from=controllerbuild /app/dist/compiled /app
-
-USER node
 WORKDIR /app
-
-ENTRYPOINT ["node", "/app/index.js"]
+COPY --chown=node:node --from=build /app/node_modules ./node_modules
+COPY --chown=node:node --from=build /app/defaultConfig.json /app/package.json ./
+COPY --chown=node:node --from=build /app/dist ./dist
+COPY --chown=node:node --from=build /app/logger ./logger
+COPY --chown=node:node --from=build /app/web ./web
+USER node
+ENV NODE_ENV=production
+ENTRYPOINT ["node", "dist/app.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN npm run build-prod
 FROM node:current as releasecontainer
 COPY --from=controllerbuild /app/dist/compiled /app
 WORKDIR /app
-ENTRYPOINT ["node", "/app/index.js"] 
+ENTRYPOINT ["node", "/app/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
-FROM node:current as controllerbuild
+FROM node:alpine as controllerbuild
+RUN apk add --no-cache make gcc g++ python linux-headers udev tzdata
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
 RUN npm run build-prod
 
-FROM node:current as releasecontainer
-COPY --from=controllerbuild /app/dist/compiled /app
+FROM node:alpine as releasecontainer
+RUN mkdir /app && chown node:node /app
+COPY --chown=node:node --from=controllerbuild /app/dist/compiled /app
+
+USER node
 WORKDIR /app
+
 ENTRYPOINT ["node", "/app/index.js"]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
         "start": "npm run build && node dist/app.js",
         "start:cached": "node dist/app.js",
         "build": "tsc",
-        "build-prod": "ncc build app.ts -o dist/compiled",
         "watch": "tsc -w"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "start": "npm run build && node dist/app.js",
         "start:cached": "node dist/app.js",
         "build": "tsc",
+        "build-prod": "ncc build app.ts -o dist/compiled",
         "watch": "tsc -w"
     },
     "dependencies": {
@@ -36,6 +37,7 @@
         "@types/socket.io": "^2.1.11",
         "@typescript-eslint/eslint-plugin": "^3.10.1",
         "@typescript-eslint/parser": "^3.10.1",
+        "@vercel/ncc": "latest",
         "eslint": "^7.8.1",
         "eslint-config-defaults": "^9.0.0",
         "eslint-config-standard": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "node-ssdp": "^4.0.0",
         "serialport": "^9.0.1",
         "socket.io": "^2.2.0",
+        "source-map-support": "^0.5.13",
         "winston": "^3.3.3"
     },
     "devDependencies": {
@@ -37,7 +38,6 @@
         "@types/socket.io": "^2.1.11",
         "@typescript-eslint/eslint-plugin": "^3.10.1",
         "@typescript-eslint/parser": "^3.10.1",
-        "@vercel/ncc": "latest",
         "eslint": "^7.8.1",
         "eslint-config-defaults": "^9.0.0",
         "eslint-config-standard": "^14.1.0",
@@ -47,7 +47,6 @@
         "eslint-plugin-standard": "^4.0.1",
         "grunt": "^1.3.0",
         "grunt-banner": "^0.6.0",
-        "source-map-support": "^0.5.13",
         "ts-node": "^8.10.2",
         "typescript": "^3.9.7"
     }


### PR DESCRIPTION
- Update Dockerfile to use node:alpine as the base image in order to keep the docker image to a reasonable size.  Run njsPC as non-root user.