### PR TITLE
add git to final stage to avoid git errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN npm run build
 RUN npm ci --production
 
 FROM node:lts-alpine as prod
+RUN apk add git
 RUN mkdir /app && chown node:node /app
 WORKDIR /app
 COPY --chown=node:node --from=build /app .


### PR DESCRIPTION
fixes 

```
error: Unable to retrieve local git branch.  Error: Command failed: git rev-parse --abbrev-ref HEAD
/bin/sh: git: not found

/bin/sh: git: not found
] error: Unable to retrieve local git commit.  Error: Command failed: git rev-parse HEAD
/bin/sh: git: not found
```
when running in container
