### PR TITLE
Revert "fix home assistant discovery of lights"

### DIFF
--- a/web/bindings/homeassistant.json
+++ b/web/bindings/homeassistant.json
@@ -89,7 +89,7 @@
               "device: device_id,",
               "command_on_template: `{\"id\": ${data.id}, \"isOn\": true}`,",
               "command_off_template: `{\"id\": ${data.id}, \"isOn\": false}`,",
-              "state_value_template: '{{value_json.isOn}}'});"
+              "state_template: '{{value_json.isOn}}'});"
             ],
             "filter": "@bind=data.showInFeatures; === true && @bind=data.type.isLight; === true"
           }


### PR DESCRIPTION
Reverts tagyoureit/nodejs-poolController#612

🤦  my bad, this was wrong. I wasn't yet aware of `schema: template`, which this is using. It was correct before.