### PR TITLE
support setting lightingTheme via MQTT

### DIFF
--- a/web/bindings/homeassistant.json
+++ b/web/bindings/homeassistant.json
@@ -85,12 +85,20 @@
               "availability_template: \"{{'online' if value_json.name == 'ready' else 'offline'}}\",",
               "schema: 'template',",
               "command_topic: `${ctx.vars.mqttTopic}/state/circuits/setState`,",
-              "state_topic: `${ctx.vars.mqttTopic}/state/circuits/${data.id}/${data.name.replace(/\\s+/g, '').toLowerCase()}`,",
+              "state_topic: `${ctx.vars.mqttTopic}/state/circuits/${data.id}/${data.name.replace(/\\s+/g, '').toLowerCase()}/state`,",
               "device: device_id,",
-              "command_on_template: `{\"id\": ${data.id}, \"isOn\": true}`,",
+              "effect_list: sys.circuits.getInterfaceById(data.id).getLightThemes().map(t => t.name),",
+              "command_on_template: `{\"id\": ${data.id}, \"isOn\": true{%if effect is defined%}, \"lightingTheme\": \"{{effect}}\"{%endif%}}`,",
               "command_off_template: `{\"id\": ${data.id}, \"isOn\": false}`,",
-              "state_template: '{{value_json.isOn}}'});"
+              "state_template: '{{value_json.isOn}}',",
+              "effect_template: '{{value_json.lightingTheme.name}}'});"
             ],
+            "filter": "@bind=data.showInFeatures; === true && @bind=data.type.isLight; === true"
+          },
+          {
+            "topic": "@bind=vars.mqttTopic;/state/circuits/@bind=data.id;/@bind=data.name;/state",
+            "useRootTopic": false,
+            "message": "{\"id\":@bind=data.id;,\"isOn\":@bind=data.isOn?'\"on\"':'\"off\"';,\"lightingTheme\":@bind=data.lightingTheme;}",
             "filter": "@bind=data.showInFeatures; === true && @bind=data.type.isLight; === true"
           }
       ]

--- a/web/interfaces/mqttInterface.ts
+++ b/web/interfaces/mqttInterface.ts
@@ -389,11 +389,23 @@ export class MqttInterfaceBindings extends BaseInterfaceBindings {
                             logger.error(`Inbound MQTT ${topics} has an invalid id (${id}) in the message (${msg}).`)
                         };
                         let isOn = typeof msg.isOn !== 'undefined' ? utils.makeBool(msg.isOn) : typeof msg.state !== 'undefined' ? utils.makeBool(msg.state) : undefined;
+                        var lightingTheme;
+                        if (typeof msg.lightingTheme === 'string') {
+                            logger.info("searching for light theme");
+                            lightingTheme = sys.board.valueMaps.lightThemes.transformByName(msg.lightingTheme);
+                            logger.info(`found light theme ${JSON.stringify(lightingTheme)}`);
+                            if (typeof lightingTheme !== 'undefined') lightingTheme = lightingTheme.val;
+                        }
                         switch (topics[topics.length - 2].toLowerCase()) {
                             case 'circuits':
                             case 'circuit': {
                                 try {
-                                    if(typeof isOn !== 'undefined') await sys.board.circuits.setCircuitStateAsync(id, isOn);
+                                    if(typeof lightingTheme !== 'undefined') {
+                                        logger.info(`setting light theme of ${id} to ${lightingTheme}`)
+                                        await sys.board.circuits.setLightThemeAsync(id, lightingTheme);
+                                    } else if(typeof isOn !== 'undefined') {
+                                        await sys.board.circuits.setCircuitStateAsync(id, isOn);
+                                    }
                                 }
                                 catch (err) { logger.error(err); }
                                 break;


### PR DESCRIPTION
also publish the proper metadata for it to work via Home Assistant. note that this requires publishing an additional state topic that includes both the on/off state and the theme in a single topic (HASS can't deal with a single topic for commands and separated topics for state - it either needs to be a single topic for all attributes on both state and command, or it needs to be separate topics for each attribute on both state and command).