### PR TITLE
logic bug when checking if a schedule is valid for today

### DIFF
--- a/controller/boards/IntelliCenterBoard.ts
+++ b/controller/boards/IntelliCenterBoard.ts
@@ -2258,9 +2258,9 @@ class IntelliCenterCircuitCommands extends CircuitCommands {
                     let dow = dt.getDay();
                     // Convert the dow to the bit value.
                     let sd = sys.board.valueMaps.scheduleDays.toArray().find(elem => elem.dow === dow);
-                    let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
+                    //let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
                     let ts = dt.getHours() * 60 + dt.getMinutes();
-                    if ((sched.scheduleDays & dayVal) > 0 && ts >= sched.startTime && ts <= sched.endTime) byte = byte | (1 << bit);
+                    if ((sched.scheduleDays & sd.bitval) > 0 && ts >= sched.startTime && ts <= sched.endTime) byte = byte | (1 << bit);
                 }
             }
             else if (sched.isOn) byte = byte | (1 << bit);

--- a/controller/boards/SystemBoard.ts
+++ b/controller/boards/SystemBoard.ts
@@ -3717,7 +3717,7 @@ export class ScheduleCommands extends BoardCommands {
       let dow = dt.getDay();
       // Convert the dow to the bit value.
       let sd = sys.board.valueMaps.scheduleDays.toArray().find(elem => elem.dow === dow);
-      let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
+      //let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
       let ts = dt.getHours() * 60 + dt.getMinutes();
       for (let i = 0; i < state.schedules.length; i++) {
         let schedIsOn: boolean;
@@ -3725,7 +3725,7 @@ export class ScheduleCommands extends BoardCommands {
         let scirc = state.circuits.getInterfaceById(ssched.circuit);
         let mOP = sys.board.schedules.manualPriorityActive(ssched);  //sys.board.schedules.manualPriorityActiveByProxy(scirc.id);
         if (scirc.isOn && !mOP &&
-          (ssched.scheduleDays & dayVal) > 0 &&
+          (ssched.scheduleDays & sd.bitval) > 0 &&
           ts >= ssched.startTime && ts <= ssched.endTime) schedIsOn = true
         else schedIsOn = false;
         if (schedIsOn !== ssched.isOn) {

--- a/controller/nixie/schedules/Schedule.ts
+++ b/controller/nixie/schedules/Schedule.ts
@@ -275,9 +275,9 @@ export class NixieSchedule extends NixieEquipment {
         else {
             // Convert the dow to the bit value.
             let sd = sys.board.valueMaps.scheduleDays.toArray().find(elem => elem.dow === dow);
-            let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
+            //let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
             // First check to see if today is one of our days.
-            if ((this.schedule.scheduleDays & dayVal) === 0) return false;
+            if ((this.schedule.scheduleDays & sd.bitval) === 0) return false;
         }
         // Next normalize our start and end times.  Fortunately, the start and end times are normalized here so that
         // [0, {name: 'manual', desc: 'Manual }]


### PR DESCRIPTION
There is both a typo and a logic error in the code that parses through each schedule object and checks to see if that schedule object is valid for today. The result is this:

![schedule err 1](https://github.com/tagyoureit/nodejs-poolController/assets/10177469/7a81f888-ddae-4b23-88d0-1ca549b9d2c2)

The typo is related to this line of code, which appears in nixie/schedules/Schedule.ts, boards/SystemBoard.ts, and boards/IntelliCenterBoard.ts:

`let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.`

"bitVal" is not an element of the scheduleDays array, however "bitval" is an element. Notice the casing typo.

This results in a logic error, as "bitVal" is undefined at runtime, and the logical OR operator in JS evaluates truthy-ness such that if the LHV is undefined, then the result is the RHV. Thus dayVal will always be assigned to sd.val in this situation.

dayVal is used a few lines below in each of these files in a bitwise AND operation against the current schedules bitmask of valid days. However, dayVal being assigned to sd.val due to the above typo, means that dayVal contains the index number of the array element scheduleDays, not the bitmask.

`if ((this.schedule.scheduleDays & dayVal) === 0) return false;`

So this line of code is calculating a bitwise AND operation between a **bitmask of days** and an **array index**, which is why you see the error in the above screen shot. 

The fix is to do the bitwise AND operation against this.schedule.scheduleDays (the bitmask of the schedule object currently being evaluated) and sd.bitval (today's bitmask).

However, I note the comment "allows mask overrides" in the affected code. I am not sure what this line of code was intended to achieve and if the index of the scheduleDays array was intended to do something that I am not able to intuit. Please take a look at this and make sure my edits retain the mask override logic that was intended.

After this fix, schedules work fine (for me, with no overrides that I am aware of), as seen below:

![schedule err 2](https://github.com/tagyoureit/nodejs-poolController/assets/10177469/bef47c66-e0b4-455f-ad5b-6f16015a58ad)



