### PR TITLE
fix for circuits with schedules that overlap in a polling window

### DIFF
--- a/controller/boards/IntelliCenterBoard.ts
+++ b/controller/boards/IntelliCenterBoard.ts
@@ -2258,9 +2258,9 @@ class IntelliCenterCircuitCommands extends CircuitCommands {
                     let dow = dt.getDay();
                     // Convert the dow to the bit value.
                     let sd = sys.board.valueMaps.scheduleDays.toArray().find(elem => elem.dow === dow);
-                    let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
+                    //let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
                     let ts = dt.getHours() * 60 + dt.getMinutes();
-                    if ((sched.scheduleDays & dayVal) > 0 && ts >= sched.startTime && ts <= sched.endTime) byte = byte | (1 << bit);
+                    if ((sched.scheduleDays & sd.bitval) > 0 && ts >= sched.startTime && ts <= sched.endTime) byte = byte | (1 << bit);
                 }
             }
             else if (sched.isOn) byte = byte | (1 << bit);

--- a/controller/boards/SystemBoard.ts
+++ b/controller/boards/SystemBoard.ts
@@ -3717,7 +3717,7 @@ export class ScheduleCommands extends BoardCommands {
       let dow = dt.getDay();
       // Convert the dow to the bit value.
       let sd = sys.board.valueMaps.scheduleDays.toArray().find(elem => elem.dow === dow);
-      let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
+      //let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
       let ts = dt.getHours() * 60 + dt.getMinutes();
       for (let i = 0; i < state.schedules.length; i++) {
         let schedIsOn: boolean;
@@ -3725,7 +3725,7 @@ export class ScheduleCommands extends BoardCommands {
         let scirc = state.circuits.getInterfaceById(ssched.circuit);
         let mOP = sys.board.schedules.manualPriorityActive(ssched);  //sys.board.schedules.manualPriorityActiveByProxy(scirc.id);
         if (scirc.isOn && !mOP &&
-          (ssched.scheduleDays & dayVal) > 0 &&
+          (ssched.scheduleDays & sd.bitval) > 0 &&
           ts >= ssched.startTime && ts <= ssched.endTime) schedIsOn = true
         else schedIsOn = false;
         if (schedIsOn !== ssched.isOn) {

--- a/controller/nixie/schedules/Schedule.ts
+++ b/controller/nixie/schedules/Schedule.ts
@@ -275,9 +275,9 @@ export class NixieSchedule extends NixieEquipment {
         else {
             // Convert the dow to the bit value.
             let sd = sys.board.valueMaps.scheduleDays.toArray().find(elem => elem.dow === dow);
-            let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
+            //let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
             // First check to see if today is one of our days.
-            if ((this.schedule.scheduleDays & dayVal) === 0) return false;
+            if ((this.schedule.scheduleDays & sd.bitval) === 0) return false;
         }
         // Next normalize our start and end times.  Fortunately, the start and end times are normalized here so that
         // [0, {name: 'manual', desc: 'Manual }]

--- a/controller/nixie/schedules/Schedule.ts
+++ b/controller/nixie/schedules/Schedule.ts
@@ -212,6 +212,9 @@ export class NixieSchedule extends NixieEquipment {
                 this.running = true;
             }
             else if (shouldBeOn && this.running) {
+                // Check to see if circuit is on, if not, turn it on
+                if (!cstate.isOn) ctx.setCircuit(circuit.id, true);
+
                 // With mOP, we need to see if the schedule will come back into play and also set the circut
                 if (this.suspended && cstate.isOn) {
                     if (sys.general.options.manualPriority) {


### PR DESCRIPTION
Sorry about all these issues and pull requests. I'm just discovering things as I get Nixie setup to run the way I need it to, and well, I'm finding things.

I have this weird schedule because I have a higher electricity cost between 15:00-18:00 on weekdays. So I don't want to run the pool during those hours.

![schedbug2](https://github.com/tagyoureit/nodejs-poolController/assets/10177469/46adfb73-ede6-4fb3-abe6-9fac808ea031)

When the midnight (00:00) time is crossed, schedule 2 will be turned off as expected, however schedule 1 will not be turned on. 

Here's what happens:
1. At the 23:59:59 poll
   - schedule 1 is inactive (shouldBeOn false; this.running false; ssched.isOn false; cstate.isOn true)
   - schedule 2 is active (shouldBeOn true; this.running true; ssched.isOn true; cstate.isOn true)
2. At the 00:00:02 poll:
   - schedule 1 is inactive (shouldBeOn true; this.running false; ssched.isOn false; cstate.isOn true)
   - schedule 2 is active (shouldBeOn false; this.running true; ssched.isOn true; cstate.isOn true)
   So schedule 2 gets turned off as expected, and schedule 1 is turned on as expected
   And the pool circuit is turned off, due to schedule 2 being turned off.
   [7/5/2023, 12:00:02 AM] verbose: Suspending status check: true -- 2
   [7/5/2023, 12:00:02 AM] verbose: Turning off a body circuit Pool
   [7/5/2023, 12:00:02 AM] info: NCP: Setting Circuit Pool to false

3. At the 00:00:05 poll
   - schedule 1 is active (shouldBeOn true; this.running true; ssched.isOn true; cstate.isOn false)
   - schedule 2 is inactive (shouldBeOn false; this.running false; ssched.isOn false; cstate.isOn false)
   The pool circuit is NOT turned back on, so while the schedule is "on", the associated circuit is "off".

There is a workaround. Setting the End Time to 23:59 instead of 24:00 means that the two schedules are not both checked within the same 3000ms polling window.
   
The easiest way to fix this, I think, is when checking if a schedule should be on, and is running, is to see if the associated circuit is also on, and if not, turn it on. One line of code will do this. However, this is a noticeably complex function, and I would ask that our humble developers ensure that this doesn't have any unexpected effects. Additionally, rather than just `ctx.setCircuit(circuit.id, true)`, should we also be repeating the same heat source logic from a few lines above? ("If these are body circuits then we need to determine whether we will be setting the setpoints/heatmode on the body." In this latter case, it may make sense to break that out into a separate function rather than duplicating the code.

Regardless, in my testing this one line of code fixes it for me, and I have not seen anything unexpected (yet).

   