### PR TITLE
Correcting logic in isNight function

### DIFF
--- a/controller/Constants.ts
+++ b/controller/Constants.ts
@@ -126,12 +126,16 @@ export class Heliotrope {
         return dtLocal;
     }
     public get isNight(): boolean {
+        if (!this.isValid) return false;
+
         let times = this.calculatedTimes;
-        if (this.isValid) {
-            let time = new Date().getTime();
-            if (time >= times.sunset.getTime() && time < times.sunrise.getTime()) return true;
-        }
-        return false;
+        let sunriseMins = times.sunrise.getHours() * 60 + times.sunrise.getMinutes();
+        let sunsetMins = times.sunset.getHours() * 60 + times.sunset.getMinutes();
+        let now = new Date()
+        let nowMins = now.getHours() * 60 + now.getMinutes();
+
+        if (nowMins > sunriseMins && nowMins <= sunsetMins) return false;
+        else return true;
     }
     public calculate() {
         if (typeof this.dt !== 'undefined'

--- a/controller/boards/IntelliCenterBoard.ts
+++ b/controller/boards/IntelliCenterBoard.ts
@@ -2258,9 +2258,9 @@ class IntelliCenterCircuitCommands extends CircuitCommands {
                     let dow = dt.getDay();
                     // Convert the dow to the bit value.
                     let sd = sys.board.valueMaps.scheduleDays.toArray().find(elem => elem.dow === dow);
-                    let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
+                    //let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
                     let ts = dt.getHours() * 60 + dt.getMinutes();
-                    if ((sched.scheduleDays & dayVal) > 0 && ts >= sched.startTime && ts <= sched.endTime) byte = byte | (1 << bit);
+                    if ((sched.scheduleDays & sd.bitval) > 0 && ts >= sched.startTime && ts <= sched.endTime) byte = byte | (1 << bit);
                 }
             }
             else if (sched.isOn) byte = byte | (1 << bit);

--- a/controller/boards/SystemBoard.ts
+++ b/controller/boards/SystemBoard.ts
@@ -3717,7 +3717,7 @@ export class ScheduleCommands extends BoardCommands {
       let dow = dt.getDay();
       // Convert the dow to the bit value.
       let sd = sys.board.valueMaps.scheduleDays.toArray().find(elem => elem.dow === dow);
-      let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
+      //let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
       let ts = dt.getHours() * 60 + dt.getMinutes();
       for (let i = 0; i < state.schedules.length; i++) {
         let schedIsOn: boolean;
@@ -3725,7 +3725,7 @@ export class ScheduleCommands extends BoardCommands {
         let scirc = state.circuits.getInterfaceById(ssched.circuit);
         let mOP = sys.board.schedules.manualPriorityActive(ssched);  //sys.board.schedules.manualPriorityActiveByProxy(scirc.id);
         if (scirc.isOn && !mOP &&
-          (ssched.scheduleDays & dayVal) > 0 &&
+          (ssched.scheduleDays & sd.bitval) > 0 &&
           ts >= ssched.startTime && ts <= ssched.endTime) schedIsOn = true
         else schedIsOn = false;
         if (schedIsOn !== ssched.isOn) {

--- a/controller/boards/SystemBoard.ts
+++ b/controller/boards/SystemBoard.ts
@@ -4269,12 +4269,13 @@ export class HeaterCommands extends BoardCommands {
                                                 isOn = true;
                                                 body.heatStatus = sys.board.valueMaps.heatStatus.getValue('solar');
                                                 isHeating = true;
+						isCooling = false;
                                             }
                                             else if (heater.coolingEnabled && body.temp > cfgBody.coolSetpoint && state.heliotrope.isNight &&
-                                                state.temps.solar > body.temp + (hstate.isOn ? heater.stopTempDelta : heater.startTempDelta)) {
+                                                state.temps.solar < cfgBody.coolSetpoint + (hstate.isOn ? heater.stopTempDelta : heater.startTempDelta)) {
                                                 isOn = true;
                                                 body.heatStatus = sys.board.valueMaps.heatStatus.getValue('cooling');
-                                                isHeating = true;
+                                                isHeating = false;
                                                 isCooling = true;
                                             }
                                         }

--- a/controller/nixie/schedules/Schedule.ts
+++ b/controller/nixie/schedules/Schedule.ts
@@ -275,9 +275,9 @@ export class NixieSchedule extends NixieEquipment {
         else {
             // Convert the dow to the bit value.
             let sd = sys.board.valueMaps.scheduleDays.toArray().find(elem => elem.dow === dow);
-            let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
+            //let dayVal = sd.bitVal || sd.val;  // The bitval allows mask overrides.
             // First check to see if today is one of our days.
-            if ((this.schedule.scheduleDays & dayVal) === 0) return false;
+            if ((this.schedule.scheduleDays & sd.bitval) === 0) return false;
         }
         // Next normalize our start and end times.  Fortunately, the start and end times are normalized here so that
         // [0, {name: 'manual', desc: 'Manual }]

--- a/controller/nixie/schedules/Schedule.ts
+++ b/controller/nixie/schedules/Schedule.ts
@@ -212,6 +212,9 @@ export class NixieSchedule extends NixieEquipment {
                 this.running = true;
             }
             else if (shouldBeOn && this.running) {
+                // Check to see if circuit is on, if not, turn it on
+                if (!cstate.isOn) ctx.setCircuit(circuit.id, true);
+
                 // With mOP, we need to see if the schedule will come back into play and also set the circut
                 if (this.suspended && cstate.isOn) {
                     if (sys.general.options.manualPriority) {


### PR DESCRIPTION
The isNight method in Constants.ts currently considers the date part of the timestamp rather than just the time part of the timestamp. As such, something like this results in isNight returning false. Note that sunrise in this case refers to yesterday's sunrise, rather then today's sunrise.

```
sunset  "2023-07-08T02:40:21.000Z" 16887 84021000
now     "2023-07-08T06:38:51.565Z" 16887 98331565
sunrise "2023-07-07T12:23:02.000Z" 16887 32582000
```

To solve for this, we just need to 1) ignore the date part and 2) change the logic to return false if its "daytime", as "day" will never cross the midnight boundary. The logic as currently written checks for "nighttime", and would need additional complexity to account for the midnight boundary. Checking for "daytime" is easier.
