### PR TITLE
Fix inconsistent replacement of spaces in body name leading to unusable MQTT bindings in HA

### DIFF
--- a/defaultConfig.json
+++ b/defaultConfig.json
@@ -164,7 +164,7 @@
           "username": "",
           "password": "",
           "selfSignedCertificate": false,
-          "rootTopic": "@bind=(state.equipment.model).replace(' ','-').replace('/','').toLowerCase();",
+          "rootTopic": "@bind=(state.equipment.model).replace(/ /g,'-').replace('/','').toLowerCase();",
           "retain": true,
           "qos": 0,
           "changesOnly": true
@@ -204,7 +204,7 @@
           "port": 1883,
           "username": "",
           "password": "",
-          "rootTopic": "@bind=(state.equipment.model).replace(' ','-').replace('/','').toLowerCase();Alt",
+          "rootTopic": "@bind=(state.equipment.model).replace(/ /,'-').replace('/','').toLowerCase();Alt",
           "retain": true,
           "qos": 0,
           "changesOnly": true
@@ -230,7 +230,7 @@
         "vars": {
           "_note": "hassTopic is the topic that HASS reads for configuration and should not be changed.  mqttTopic should match the topic in the MQTT binding (do not use MQTTAlt for HASS).",
           "hassTopic": "homeassistant",
-          "mqttTopic": "@bind=(state.equipment.model).replace(' ','-').replace('/','').toLowerCase();"
+          "mqttTopic": "@bind=(state.equipment.model).replace(/ /g,'-').replace('/','').toLowerCase();"
         }
       },
       "rem": {

--- a/web/bindings/homeassistant.json
+++ b/web/bindings/homeassistant.json
@@ -34,7 +34,7 @@
         }
       ],
       "rootTopic-DIRECTIONS": "rootTopic in config.json is ingored. Instead set the two topic variables in the vars section",
-      "_rootTopic": "@bind=(state.equipment.model).replace(' ','-').replace(' / ','').toLowerCase();",
+      "_rootTopic": "@bind=(state.equipment.model).replace(/ /g,'-').replace(' / ','').toLowerCase();",
       "clientId": "@bind=`hass_njsPC_${webApp.mac().replace(/:/g, '_'}-${webApp.httpPort()}`;"
     }
   },

--- a/web/services/utilities/Utilities.ts
+++ b/web/services/utilities/Utilities.ts
@@ -103,7 +103,7 @@ export class UtilitiesRoute {
                             options: {
                                 protocol: 'mqtt://', host: '', port: 1883, username: '', password: '',
                                 selfSignedCertificate: false,
-                                rootTopic: "pool/@bind=(state.equipment.model).replace(' ','-').replace(' / ','').toLowerCase();",
+                                rootTopic: "pool/@bind=(state.equipment.model).replace(/ /g,'-').replace(' / ','').toLowerCase();",
                                 retain: true, qos: 0, changesOnly: true
                             }
                         }


### PR DESCRIPTION
Fixed inconsistent replacement of spaces in body name that led to unusable MQTT bindings in HA.

For example, this is what was published for HA auto-discovery. Node the space between "single" and "body".
```
{
  "name": "Chem Controller pH",
  "unique_id": "poolController-50-chemcontroller-ph",
  "availability_topic": "nixie-single body/state/status",
  "availability_template": "{{'online' if value_json.name == 'ready' else 'offline'}}",
  "device": {
    "name": "Pool Controller - njsPC",
    "ids": [
      "nixie-single-body"
    ],
    "suggested_area": "Pool"
  },
  "icon": "mdi:ph",
  "state_class": "measurement",
  "state_topic": "nixie-single body/state/chemControllers/50/chemcontroller/ph/level"
}
```

And this is the topic that was actually published. No space between "single" and "body".
```
nixie-singlebody/state/chemControllers/50/chemcontroller/ph/tankLevel
```

I fixed this to replace all spaces in the topic root from spaces to dashes instead of only the first one.