### PR TITLE
Load Screenlogic Recurring Schedules / Version Correctly

### DIFF
--- a/controller/comms/ScreenLogic.ts
+++ b/controller/comms/ScreenLogic.ts
@@ -87,7 +87,7 @@ export class ScreenLogicComms {
           logger.screenlogic(msg);
         })
         let ver = await this._client.getVersionAsync();
-        logger.info(`Screenlogic: connect to ${systemName} ${ver} at ${unit.ipAddr}:${unit.port}`);
+        logger.info(`Screenlogic: connect to ${systemName} ${ver.version} at ${unit.ipAddr}:${unit.port}`);
 
         let addClient = await this._client.addClientAsync();
         logger.silly(`Screenlogic:Add client result: ${addClient}`);
@@ -1111,12 +1111,12 @@ class Controller {
         Run once schedules: [{"scheduleId":12,"circuitId":6,"startTime":"0800","stopTime":"1100","dayMask":1,"flags":1,"heatCmd":4,"heatSetPoint":70,"days":["Mon"]},{"scheduleId":13,"circuitId":6,"startTime":"0800","stopTime":"1100","dayMask":1,"flags":1,"heatCmd":4,"heatSetPoint":70,"days":["Mon"]}] */
 
     for (let i = 0; i < slrecurring.data.length; i++) {
-      let slsched = slrecurring[i];
+      let slsched = slrecurring.data[i];
       let data = {
         id: slsched.scheduleId,
         circuit: slsched.circuitId,
-        startTime: Math.floor(slsched.startTime / 100) * 60 + slsched.startTime % 100,
-        endTime: Math.floor(slsched.stopTime / 100) * 60 + slsched.stopTime % 100,
+        startTime: Math.floor(parseInt(slsched.startTime) / 100) * 60 + parseInt(slsched.startTime) % 100,
+        endTime: Math.floor(parseInt(slsched.stopTime) / 100) * 60 + parseInt(slsched.stopTime) % 100,
         scheduleDays: slsched.dayMask,
         changeHeatSetPoint: slsched.heatCmd > 0,
         heatSetPoint: slsched.heatSetPoint,


### PR DESCRIPTION
This PR address #1042 - the `${ver}` here was an object, with a `senderId`, so using `${ver.version}` is required.

Prior to this, the version output would read:

`Screenlogic: connect to Pentair: 00-00-00 [object Object]`

It now correctly reads: `Screenlogic: connect to Pentair: 00-00-00 POOL: 5.2 Build 738.0 Rel`

Additionally, for some reason the scheduling object for recurring was attempting to access the `slrecurring` object directly, instead of via the data array. 

Prior to this, the error would read: `[11/16/2024, 4:57:12 PM] error: Screenlogic: Error getting schedules. Cannot read properties of undefined (reading 'scheduleId')` when trying to load recurring schedules (or any schedules).

