### PR TITLE
Fix missing argument in InvalidEquipmentIdError introduced in ae6f8702

### DIFF
--- a/controller/boards/NixieBoard.ts
+++ b/controller/boards/NixieBoard.ts
@@ -1239,7 +1239,7 @@ export class NixieCircuitCommands extends CircuitCommands {
     }
     public async deleteCircuitGroupAsync(obj: any): Promise<CircuitGroup> {
         let id = parseInt(obj.id, 10);
-        if (isNaN(id)) return Promise.reject(new InvalidEquipmentIdError(`Invalid group id: ${obj.id}`, 'CircuitGroup'));
+        if (isNaN(id)) return Promise.reject(new InvalidEquipmentIdError(`Invalid group id: ${obj.id}`, obj.id, 'CircuitGroup'));
         if (!sys.board.equipmentIds.circuitGroups.isInRange(id)) return;
         if (typeof obj.id !== 'undefined') {
             let group = sys.circuitGroups.getItemById(id, false);
@@ -1257,7 +1257,7 @@ export class NixieCircuitCommands extends CircuitCommands {
     }
     public async deleteLightGroupAsync(obj: any): Promise<LightGroup> {
         let id = parseInt(obj.id, 10);
-        if (isNaN(id)) return Promise.reject(new InvalidEquipmentIdError(`Invalid group id: ${obj.id}`, 'LightGroup'));
+        if (isNaN(id)) return Promise.reject(new InvalidEquipmentIdError(`Invalid group id: ${obj.id}`, obj.id, 'LightGroup'));
         if (!sys.board.equipmentIds.circuitGroups.isInRange(id)) return;
         if (typeof obj.id !== 'undefined') {
             let group = sys.lightGroups.getItemById(id, false);


### PR DESCRIPTION
Adds the missing second argument (obj.id) to two InvalidEquipmentIdError calls introduced in ae6f8702. The omission was causing a compile-time error.