### PR TITLE
Added Century (Regal) Modbus pump support

### DIFF
--- a/controller/Equipment.ts
+++ b/controller/Equipment.ts
@@ -1478,7 +1478,7 @@ export class Pump extends EqItem {
     public set id(val: number) { this.setDataVal('id', val); }
     public get portId(): number { return this.data.portId; }
     public set portId(val: number) { this.setDataVal('portId', val); }
-    public get address(): number { return this.data.address || this.data.id + 95; }
+    public get address(): number { return this.data.address; }
     public set address(val: number) { this.setDataVal('address', val); }
     public get name(): string { return this.data.name; }
     public set name(val: string) { this.setDataVal('name', val); }

--- a/controller/State.ts
+++ b/controller/State.ts
@@ -947,7 +947,7 @@ export class PumpState extends EqState {
     }
     public get id(): number { return this.data.id; }
     public set id(val: number) { this.data.id = val; }
-    public get address(): number { return this.data.address || this.data.id + 95; }
+    public get address(): number { return this.data.address; }
     public set address(val: number) { this.setDataVal('address', val); }
     public get name(): string { return this.data.name; }
     public set name(val: string) { this.setDataVal('name', val); }
@@ -1042,6 +1042,7 @@ export class PumpState extends EqState {
                 case 'hwvs':
                 case 'vssvrs':
                 case 'vs':
+                case 'regalmodbus':
                     c.units = sys.board.valueMaps.pumpUnits.transformByName('rpm');
                     break;
                 case 'ss':

--- a/controller/boards/NixieBoard.ts
+++ b/controller/boards/NixieBoard.ts
@@ -29,6 +29,12 @@ import { webApp } from "../../web/Server";
 import { setTimeout } from 'timers/promises';
 import { setTimeout as setTimeoutSync } from 'timers';
 
+const addrsPentairPump = Object.freeze([96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111]);
+const addrsRegalModbusPump = Object.freeze(
+    Array.from({ length: ((0xF7 - 0x15) / 2) + 1 }, (_, i) => 0x15 + i * 2)  // Odd numbers fro 0x15 through 0xF7
+  );
+
+
 export class NixieBoard extends SystemBoard {
     constructor (system: PoolSystem){
         super(system);
@@ -76,14 +82,15 @@ export class NixieBoard extends SystemBoard {
             [17, { name: 'watercolors', desc: 'WaterColors', isLight: true, theme: 'watercolors' }],
         ]);
         this.valueMaps.pumpTypes = new byteValueMap([
-            [1, { name: 'ss', desc: 'Single Speed', maxCircuits: 8, hasAddress: false, hasBody: false, maxRelays: 1, relays: [{ id: 1, name: 'Pump On/Off' }]}],
-            [2, { name: 'ds', desc: 'Two Speed', maxCircuits: 8, hasAddress: false, hasBody: false, maxRelays: 2, relays: [{ id: 1, name: 'Low Speed' }, { id: 2, name: 'High Speed' }]}],
-            [3, { name: 'vs', desc: 'Intelliflo VS', maxPrimingTime: 6, minSpeed: 450, maxSpeed: 3450, maxCircuits: 8, hasAddress: true }],
-            [4, { name: 'vsf', desc: 'Intelliflo VSF', minSpeed: 450, maxSpeed: 3450, minFlow: 15, maxFlow: 130, maxCircuits: 8, hasAddress: true }],
-            [5, { name: 'vf', desc: 'Intelliflo VF', minFlow: 15, maxFlow: 130, maxCircuits: 8, hasAddress: true }],
-            [6, { name: 'hwvs', desc: 'Hayward Eco/TriStar VS', minSpeed: 450, maxSpeed: 3450, maxCircuits: 8, hasAddress: true }],
-            [7, { name: 'hwrly', desc: 'Hayward Relay VS', hasAddress: false, maxCircuits: 8, maxRelays: 4, maxSpeeds: 8, relays: [{ id: 1, name: 'Step #1' }, { id: 2, name: 'Step #2'}, { id: 3, name: 'Step #3' }, { id: 4, name: 'Pump On' }] }],
-            [100, { name: 'sf', desc: 'SuperFlo VS', hasAddress: false, maxCircuits: 8, maxRelays: 4, equipmentMaster: 1, maxSpeeds: 4, relays: [{ id: 1, name: 'Program #1' }, { id: 2, name: 'Program #2' }, { id: 3, name: 'Program #3' }, { id: 4, name: 'Program #4' }]}]
+            [1, { name: 'ss', desc: 'Single Speed', maxCircuits: 8, hasAddress: false, hasBody: false, maxRelays: 1, relays: [{ id: 1, name: 'Pump On/Off' }], addresses: []}],
+            [2, { name: 'ds', desc: 'Two Speed', maxCircuits: 8, hasAddress: false, hasBody: false, maxRelays: 2, relays: [{ id: 1, name: 'Low Speed' }, { id: 2, name: 'High Speed' }], addresses: []}],
+            [3, { name: 'vs', desc: 'Intelliflo VS', maxPrimingTime: 6, minSpeed: 450, maxSpeed: 3450, maxCircuits: 8, hasAddress: true, addresses: addrsPentairPump }],
+            [4, { name: 'vsf', desc: 'Intelliflo VSF', minSpeed: 450, maxSpeed: 3450, minFlow: 15, maxFlow: 130, maxCircuits: 8, hasAddress: true, addresses: addrsPentairPump }],
+            [5, { name: 'vf', desc: 'Intelliflo VF', minFlow: 15, maxFlow: 130, maxCircuits: 8, hasAddress: true, addresses: addrsPentairPump }],
+            [6, { name: 'hwvs', desc: 'Hayward Eco/TriStar VS', minSpeed: 450, maxSpeed: 3450, maxCircuits: 8, hasAddress: true, addresses: addrsPentairPump }],
+            [7, { name: 'hwrly', desc: 'Hayward Relay VS', hasAddress: false, maxCircuits: 8, maxRelays: 4, maxSpeeds: 8, relays: [{ id: 1, name: 'Step #1' }, { id: 2, name: 'Step #2'}, { id: 3, name: 'Step #3' }, { id: 4, name: 'Pump On' }], addresses: [] }],
+            [100, { name: 'sf', desc: 'SuperFlo VS', hasAddress: false, maxCircuits: 8, maxRelays: 4, equipmentMaster: 1, maxSpeeds: 4, relays: [{ id: 1, name: 'Program #1' }, { id: 2, name: 'Program #2' }, { id: 3, name: 'Program #3' }, { id: 4, name: 'Program #4' }], addresses: [] }],
+            [200, { name: 'regalmodbus', desc: 'Regal Modbus', minSpeed: 450, maxSpeed: 3450, maxCircuits: 8, hasAddress: true, addresses: addrsRegalModbusPump}],
         ]);
         // RSG - same as systemBoard definition; can delete.
         this.valueMaps.heatModes = new byteValueMap([

--- a/controller/comms/messages/status/RegalModbusStateMessage.ts
+++ b/controller/comms/messages/status/RegalModbusStateMessage.ts
@@ -1,0 +1,411 @@
+/*  nodejs-poolController.  An application to control pool equipment.
+Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022.  
+Russell Goldin, tagyoureit.  russ.goldin@gmail.com
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import { Inbound, Outbound, Protocol } from "../Messages";
+import { state } from "../../../State";
+import { sys, ControllerType } from "../../../Equipment";
+import { conn } from "../../Comms";
+import { logger } from "../../../../logger/Logger";
+
+// Create a fault object to hold the fault codes and descriptions
+let faultCodes = {
+    0x21: "Software overcurrent",
+    0x22: "DC overvoltage",
+    0x23: "DC undervoltage",
+    0x26: "Hardware overcurrent",
+    0x2A: "Startup failure",
+    0x2D: "Processor - Fatal",
+    0x2E: "IGBT over temperature",
+    0x2F: "Loss of phase",
+    0x30: "Low power",
+    0x31: "Processor - Registers",
+    0x32: "Processor - Program counter",
+    0x33: "Processor - Interrupt/Execution",
+    0x34: "Processor - Clock",
+    0x35: "Processor - Flash Memory",
+    0x36: "Ras fault",
+    0x37: "Processor - ADC",
+    0x3C: "Keypad fault",
+    0x3D: "LVB data flash fault",
+    0x3E: "Comm loss fault - LVB & Drive",
+    0x3F: "Generic fault",
+    0x40: "Coherence fault",
+    0x41: "UL fault",
+    0x42: "SVRS fault type 1",
+    0x43: "SVRS fault type 2",
+    0x44: "SVRS fault type 13",
+}
+
+let nackErrors = {
+    0x01: "Command not recognized / illegal",
+    0x02: "Operand out of allowed range",
+    0x03: "Data out of range",
+    0x04: "General failure: fault mode",
+    0x05: "Incorrect command length",
+    0x06: "Command cannot be executed now",
+    0x09: "Buffer error (not used)",
+    0x0A: "Running parameters incomplete (not used)",
+}
+
+export class RegalModbusStateMessage {
+    public static process(msg: Inbound) {
+
+        // debug log the message object
+        logger.debug(`RegalModbusStateMessage.process ${JSON.stringify(msg)}`);
+
+        let addr = msg.header[0];
+        let functionCode = msg.header[1];
+        let ack = msg.header[2];
+
+        if (ack == 0x20) return;
+        if (ack in nackErrors) {
+            logger.debug(`RegalModbusStateMessage.process NACK: ${nackErrors[ack]} (Address: ${addr})`);
+            return;
+        }
+        if (ack != 0x10) {
+            logger.debug(`RegalModbusStateMessage.process Unknown ACK: ${ack} (Address: ${addr})`);
+            return;
+        }
+
+        // If we're here, we have an ack=0x10 message
+
+        let pumpCfg = sys.pumps.getPumpByAddress(addr, false, { isActive: false });
+        let pumpId = pumpCfg.id;
+        let pumpType = sys.board.valueMaps.pumpTypes.transform(pumpCfg.type);
+        let pumpState = state.pumps.getItemById(pumpId, pumpCfg.isActive === true);
+
+        logger.debug(`RegalModbusStateMessage.process.pstate ${JSON.stringify(pumpState)}`);
+
+
+        switch (functionCode) {
+            case 0x41: {  // Go
+                logger.debug(`RegalModbusStateMessage.process Go (Address: ${addr})`);
+                break;
+            }
+            case 0x42: { // Stop
+                logger.debug(`RegalModbusStateMessage.process Stop (Address: ${addr})`);
+                break;
+            }
+            case 0x43: { // Status
+                let status = msg.extractPayloadByte(0);
+                switch (status) {
+                    case 0x00: { // stop mode - motor stopped
+                        logger.debug(`RegalModbusStateMessage.process Status: Stop (Address: ${addr})`);
+                        pumpState.driveState = 0;
+                        pumpState.command = 4;  // dashPanel assumes command = 10 in running state
+                        break;
+                    }
+                    case 0x09: { // run mode - boot (motor is getting ready to spin)
+                        logger.debug(`RegalModbusStateMessage.process Status: Boot (Address: ${addr})`);
+                        pumpState.driveState = 1;
+                        pumpState.command = 10;  // dashPanel assumes command = 10 in running state
+                        break;
+                    }
+                    case 0x0B: { // run mode - vector
+                        logger.debug(`RegalModbusStateMessage.process Status: Vector (Address: ${addr})`);
+                        pumpState.driveState = 2;
+                        pumpState.command = 10;  // dashPanel assumes command = 10 in running state
+                        break;
+                    }
+                    case 0x20: { // fault mode - motor stopped
+                        logger.debug(`RegalModbusStateMessage.process Status: Fault (Address: ${addr})`);
+                        pumpState.driveState = 4;
+                        pumpState.command = 4;  // dashPanel assumes command = 10 in running state
+                        break;
+                    }
+                }
+                break;
+            }
+            case 0x44: { // Set demand
+                let mode = msg.extractPayloadByte(0);
+                let demandLo = msg.extractPayloadByte(1);
+                let demandHi = msg.extractPayloadByte(2);
+
+                switch (mode) {
+                    case 0: {  // Speed control, demand = RPM * 4
+                        let rpm = RegalModbusStateMessage.demandToRPM(demandLo, demandHi);
+                        logger.debug(`RegalModbusStateMessage.process Speed: ${rpm} (Address: ${addr})`);
+                        pumpState.rpm = rpm;
+                        break;
+                    }
+                    case 1: {  // Torque control, demand = lbf-ft * 1200
+                        logger.debug(`RegalModbusStateMessage.process Ignoring torque: ${demandLo}, ${demandHi} (Address: ${addr})`);
+                        break;
+                    }
+                    case 2: {  // Reserved (used to be flow)
+                        logger.debug(`RegalModbusStateMessage.process Ignoring reserved demand mode ${mode}: ${demandLo}, ${demandHi} (Address: ${addr})`);
+                        break;
+                    }
+                    case 3: {  // Reserved
+                        logger.debug(`RegalModbusStateMessage.process Ignoring reserved demand mode ${mode}: ${demandLo}, ${demandHi} (Address: ${addr})`);
+                        break;
+                    }
+                }
+                break;
+            }
+            case 0x45: {  // Read sensor
+                let page = msg.extractPayloadByte(0);
+                let sensorAddr = msg.extractPayloadByte(1);
+                let valueLo = msg.extractPayloadByte(2);
+                let valueHi = msg.extractPayloadByte(3);
+                let raw_value = (valueHi << 8) + valueLo;
+
+                let scaleValue = (value: number, scale: number) => {
+                    return value / scale;
+                };
+                let scaled_value;
+
+                switch (page) {
+                    case 0: {
+                        switch (sensorAddr) {
+                            case 0x00: { // Motor speed
+                                scaled_value = scaleValue(raw_value, 4);
+                                logger.debug(`RegalModbusStateMessage.process Motor speed: ${scaled_value} (Address: ${addr})`);
+                                pumpState.rpm = scaled_value;
+                                break;
+                            }
+                            case 0x01: { // Motor current
+                                scaled_value = scaleValue(raw_value, 1000);
+                                logger.debug(`RegalModbusStateMessage.process Motor current: ${scaled_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x02: { // Operating mode
+                                switch (raw_value) {
+                                    case 0: {  // Speed control
+                                        logger.debug(`RegalModbusStateMessage.process Operating mode: Speed control (Address: ${addr})`);
+                                        break;
+                                    }
+                                    case 1: {  // Torque control
+                                        logger.debug(`RegalModbusStateMessage.process Operating mode: Torque control (Address: ${addr})`);
+                                        break;
+                                    }
+                                }
+                                break;
+                            }
+                            case 0x03: { // Demand sent to motor
+                                logger.debug(`RegalModbusStateMessage.process Raw (unscaled) demand sent to motor: ${raw_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x04: { // Torque
+                                scaled_value = scaleValue(raw_value, 1200);
+                                logger.debug(`RegalModbusStateMessage.process Torque: ${scaled_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x05: { // Inverter input power
+                                logger.debug(`RegalModbusStateMessage.process Raw (unscaled) inverter input power: ${raw_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x06: { // DC bus voltage
+                                scaled_value = scaleValue(raw_value, 64);
+                                logger.debug(`RegalModbusStateMessage.process DC bus voltage: ${scaled_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x07: { // Ambient temperature
+                                scaled_value = scaleValue(raw_value, 128);
+                                logger.debug(`RegalModbusStateMessage.process Ambient temperature: ${scaled_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x08: {  // Status
+                                switch (raw_value) {
+                                    case 0x00: { // stop mode - motor stopped
+                                        logger.debug(`RegalModbusStateMessage.process Status: Stop (Address: ${addr})`);
+                                        pumpState.driveState = 0;
+                                        break;
+                                    }
+                                    case 0x09: { // run mode - boot (motor is getting ready to spin)
+                                        logger.debug(`RegalModbusStateMessage.process Status: Boot (Address: ${addr})`);
+                                        pumpState.driveState = 1;
+                                        break;
+                                    }
+                                    case 0x0B: { // run mode - vector
+                                        logger.debug(`RegalModbusStateMessage.process Status: Vector (Address: ${addr})`);
+                                        pumpState.driveState = 2;
+                                        break;
+                                    }
+                                    case 0x20: { // fault mode - motor stopped
+                                        logger.debug(`RegalModbusStateMessage.process Status: Fault (Address: ${addr})`);
+                                        pumpState.driveState = 4;
+                                        break;
+                                    }
+                                }
+                                break;
+                            }
+                            case 0x09: { // Previous fault
+                                if (raw_value in faultCodes) {
+                                    logger.debug(`RegalModbusStateMessage.process Previous fault: ${faultCodes[raw_value]} (Address: ${addr})`);
+                                } else {
+                                    logger.debug(`RegalModbusStateMessage.process Previous fault: Unknown fault code ${raw_value} (Address: ${addr})`);
+                                }
+                                break;
+                            }
+                            case 0X0A: { // Output power
+                                scaled_value = scaleValue(raw_value, 1);
+                                logger.debug(`RegalModbusStateMessage.process Shaft power (W): ${scaled_value} (Address: ${addr})`);
+                                pumpState.watts = scaled_value;
+                                break;
+                            }
+                            case 0x0B: {  // SVRS Bypass Status
+                                break;
+                            }
+                            case 0x0C: { // Number of current faults
+                                logger.debug(`RegalModbusStateMessage.process Number of current faults: ${raw_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x0D: { // Motor line voltage
+                                logger.debug(`RegalModbusStateMessage.process Raw (unscaled) motor line voltage: ${raw_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x0E: { // Ramp status
+                                logger.debug(`RegalModbusStateMessage.process Ramp status: ${raw_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x0F: { // Number of total fault
+                                logger.debug(`RegalModbusStateMessage.process Number of total faults: ${raw_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x10: { // Prime status
+                                switch (raw_value) {
+                                    case 0: { // Not priming
+                                        logger.debug(`RegalModbusStateMessage.process Prime status: Not priming (Address: ${addr})`);
+                                        break;
+                                    }
+                                    case 1: { // Priming running
+                                        logger.debug(`RegalModbusStateMessage.process Prime status: Priming running (Address: ${addr})`);
+                                        break;
+                                    }
+                                    case 2: { // Priming completed
+                                        logger.debug(`RegalModbusStateMessage.process Prime status: Priming completed (Address: ${addr})`);
+                                        break;
+                                    }
+                                }
+                                break;
+                            }
+                            case 0x11: { // Motor input power
+                                logger.debug(`RegalModbusStateMessage.process Raw (unscaled) motor input power: ${raw_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x12: { // IGBT temperature
+                                scaled_value = scaleValue(raw_value, 128);
+                                logger.debug(`RegalModbusStateMessage.process IGBT temperature: ${scaled_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x13: { // PCB temperature
+                                logger.debug(`RegalModbusStateMessage.process Raw (unscaled) PCB temperature: ${raw_value} (Address: ${addr})`);
+                                break;
+                            }
+                            case 0x14: { // Status of external input
+                                switch (raw_value) {
+                                    case 0: { // No external input
+                                        logger.debug(`RegalModbusStateMessage.process External input: No external input (Address: ${addr})`);
+                                        break;
+                                    }
+                                    case 3: { // PWM
+                                        logger.debug(`RegalModbusStateMessage.process External input: PWM (Address: ${addr})`);
+                                        break;
+                                    }
+                                    case 4: { // DI_1 present
+                                        logger.debug(`RegalModbusStateMessage.process External input: DI_1 present (Address: ${addr})`);
+                                        break;
+                                    }
+                                    case 5: { // DI_2 present
+                                        logger.debug(`RegalModbusStateMessage.process External input: DI_2 present (Address: ${addr})`);
+                                        break;
+                                    }
+                                    case 6: { // DI_3 present
+                                        logger.debug(`RegalModbusStateMessage.process External input: DI_3 present (Address: ${addr})`);
+                                        break;
+                                    }
+                                    case 7: { // DI_4 present
+                                        logger.debug(`RegalModbusStateMessage.process External input: DI_4 present (Address: ${addr})`);
+                                        break;
+                                    }
+                                    case 8: { // Serial input
+                                        logger.debug(`RegalModbusStateMessage.process External input: Serial input (Address: ${addr})`);
+                                        break;
+                                    }
+                                }
+                                break;
+                            }
+                            case 0x15: { // Reference speed
+                                scaled_value = scaleValue(raw_value, 4);
+                                logger.debug(`RegalModbusStateMessage.process Reference speed: ${scaled_value} (Address: ${addr})`);
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    default: {
+                        logger.debug(`RegalModbusStateMessage.process Page 1: ${page} (Address: ${addr}) - Not yet implemented`);
+                        break;
+                    }
+                }
+                break;
+            }
+            case 0x46: { // Read identification
+                logger.debug(`RegalModbusStateMessage.process Read identification (Address: ${addr}) - Not yet implemented`);
+                break;
+            }
+            case 0x64: { // Read/write configuration
+                logger.debug(`RegalModbusStateMessage.process Read/write configuration (Address: ${addr}) - Not yet implemented`);
+                break;
+            }
+            default: {
+                logger.debug(`RegalModbusStateMessage.process Unknown function code: ${functionCode} (Address: ${addr})`);
+                break;
+            }
+        }
+        state.emitEquipmentChanges();
+    }
+
+    public static rpmToDemand(rpm: number): [number, number] {
+        /**
+         * Converts an RPM value to a RegalModbus demand payload in speed control mode.
+         *
+         * @param {number} rpm - Desired motor speed in RPM.
+         * @returns {[number, number]} - [demand_lo, demand_hi]
+         *   - demand_lo: lower byte of demand
+         *   - demand_hi: upper byte of demand
+         * @throws {Error} - If RPM is out of valid range for RegalModbus demand (0–16383).
+         */
+        if (rpm < 0 || rpm * 4 > 0xFFFF) {
+            throw new Error("RPM is out of valid range for RegalModbus demand (0–16383)");
+        }
+
+        const rawDemand = Math.round(rpm * 4); // Scale RPM by 4
+        const demandLo = rawDemand & 0xFF;
+        const demandHi = (rawDemand >> 8) & 0xFF;
+
+        return [demandLo, demandHi];
+    }
+
+    public static demandToRPM(demandLo: number, demandHi: number): number {
+        /**
+         * Converts a RegalModbus demand payload to an RPM value.
+         *  
+         * @param {number} demandLo - Lower byte of demand.
+         * @param {number} demandHi - Upper byte of demand.
+         * @returns {number} - Motor speed in RPM.
+         * @throws {Error} - If demand is out of valid range for RPM (0–16383).
+         **/
+        const rawDemand = (demandHi << 8) | demandLo; // Combine high and low bytes
+        if (rawDemand < 0 || rawDemand > 0xFFFF) {
+            throw new Error("Demand is out of valid range for RPM (0–16383)");
+        }
+        const rpm = Math.round(rawDemand / 4); // Scale back to RPM
+        return rpm;
+    }
+}


### PR DESCRIPTION
Adds support for Century (Regal) pumps per modbus protocol.  Aside from some clean up done recently prior to submitting this pull request, this has been running without issue for months on the same RS485 port with my AquaRite.

Credit to the protocol information provided [here](https://www.troublefreepool.com/threads/century-regal-vgreen-motor-automation.238733/#post-2091522).  I've not implemented all reporting information that the motor provides, but a reasonable number of key properties were made available.

I'm running an [EVQ225](https://www.regalrexnord.com/products/electric-motors/ac-motors-nema/pump-motors/pool-pump-motors/century-2-25-hp-pool-pump-motor-1-phase-3600-rpm-115-230-v-48y-frame-tefc-evq225-evq225).

I believe this should address [Issue 1060](https://github.com/tagyoureit/nodejs-poolController/issues/1060).


** To configure the pump, an update to dashPanel is required.  I will submit a pull request with that update as well.