### PR TITLE
Fix/century pump setdrivestate error

### DIFF
--- a/controller/comms/messages/Messages.ts
+++ b/controller/comms/messages/Messages.ts
@@ -386,17 +386,25 @@ export class Inbound extends Message {
     }
     private testRegalModbusHeader(bytes: number[], ndx: number): boolean {
         // RegalModbus protocol: header, function, ack, payload, crcLo, crcHi
+        // Only accept messages from known RegalModbus pumps to avoid misidentifying noise/Broadcast fragments
         if (bytes.length > ndx + 3 && sys.controllerType === 'nixie') {
-            // address must be in the range 0x15 to 0xF7
-            // function code must be in the range 0x00 to 0x7F
-            // ack must be in 0x10, 0x20, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x09, 0x0A
             let addr = bytes[ndx];
             let func = bytes[ndx + 1];
             let ack = bytes[ndx + 2];
             let acceptableAcks = [0x10, 0x20, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x09, 0x0A];
 
-            // logger.debug('Testing RegalModbus header', bytes, addr, func, ack, acceptableAcks.includes(ack));
-            // logger.debug(`Current bytes: ${JSON.stringify(bytes)}`);
+            // First check if address matches a configured RegalModbus pump
+            let pumps = sys.pumps.get();
+            let isKnownPump = false;
+            for (let pump of pumps) {
+                if (pump.type === 200 && pump.address === addr) {
+                    isKnownPump = true;
+                    break;
+                }
+            }
+            if (!isKnownPump) {
+                return false;
+            }
 
             if (addr >= 0x15 && addr <= 0xF7 && func >= 0x00 && func <= 0x7F && acceptableAcks.includes(ack) &&
                 this.isAddressForPumpType(addr, 'regalmodbus', ['neptunemodbus'])) {

--- a/controller/comms/messages/status/RegalModbusStateMessage.ts
+++ b/controller/comms/messages/status/RegalModbusStateMessage.ts
@@ -72,10 +72,27 @@ export class RegalModbusStateMessage {
         let ack = msg.header[2];
 
         if (ack == 0x20) return;
+        
+        // Handle NACK responses
         if (ack in nackErrors) {
+            // Special handling for NACK on Go/Stop commands - indicates pump fault
+            if (functionCode === 0x41 || functionCode === 0x42) {
+                let pumpCfg = sys.pumps.getPumpByAddress(addr, false, { isActive: false });
+                let pumpId = pumpCfg.id;
+                let pumpState = state.pumps.getItemById(pumpId, pumpCfg.isActive === true);
+                let commandName = functionCode === 0x41 ? 'Go' : 'Stop';
+                let faultDesc = nackErrors[ack];
+                
+                logger.error(`RegalModbusStateMessage: Pump ${pumpCfg.name} (addr ${addr}) returned NACK to ${commandName} command - ${faultDesc}`);
+                pumpState.driveState = 4;  // Set to fault state
+                pumpState.command = 4;
+                return;
+            }
+            // Generic NACK logging for other commands
             logger.debug(`RegalModbusStateMessage.process NACK: ${nackErrors[ack]} (Address: ${addr})`);
             return;
         }
+        
         if (ack != 0x10) {
             logger.debug(`RegalModbusStateMessage.process Unknown ACK: ${ack} (Address: ${addr})`);
             return;

--- a/controller/nixie/pumps/Pump.ts
+++ b/controller/nixie/pumps/Pump.ts
@@ -1061,6 +1061,9 @@ export class NixiePumpRegalModbus extends NixiePump {
         finally { this.suspendPolling = false; }
     };
     protected async setDriveStateAsync(isRunning: boolean = true) {
+        // Go command starts the motor spinning. The Set Demand command must be sent first. If the motor is
+        // already running, the Go command is ignored. If the motor is in the fault mode, NACK response with the
+        // "General Failure" NACK code is replied back
         let functionCode = this._targetSpeed > 0 ? 0x41 : 0x42;
         logger.debug(`NixiePumpRegalModbus: setDriveStateAsync ${this.pump.name} ${functionCode == 0x41 ? 'RUN' : functionCode == 0x42 ? 'STOP' : 'UNKNOWN'}`);
         try {
@@ -1072,8 +1075,8 @@ export class NixiePumpRegalModbus extends NixiePump {
                     dest: this.pump.address,
                     action: functionCode,
                     payload: [],
-                    retries: 1,
-                    response: true
+                    retries: 0,
+                    response: false
                 });
                 try {
                     await out.sendAsync();


### PR DESCRIPTION
This pull request focuses on improving the reliability and accuracy of RegalModbus pump communication in the Nixie controller system. The main changes ensure that only messages from known, configured RegalModbus pumps are accepted, and they refine how drive state commands are sent to these pumps.

**Inbound message filtering improvements:**

* Updated the `testRegalModbusHeader` method in `Messages.ts` to only accept messages from RegalModbus pumps that are explicitly configured in the system, preventing misidentification of noise or broadcast fragments.

**Pump command handling adjustments:**

* Added clarifying comments in `NixiePumpRegalModbus.setDriveStateAsync` about the behavior of the Go command and its requirements for the motor state and error handling.
* Changed the outbound command options in `setDriveStateAsync` to use zero retries and not expect a response, likely to avoid unnecessary command retries or waiting for responses that may not be sent in certain pump states.