### PR TITLE
Fix chlorId fallback when useChlorinator is true in setORPAsync

### DIFF
--- a/controller/nixie/chemistry/ChemController.ts
+++ b/controller/nixie/chemistry/ChemController.ts
@@ -1974,24 +1974,25 @@ export class NixieChemicalORP extends NixieChemical {
             if (typeof data !== 'undefined') {
                 this.orp.useChlorinator = typeof data.useChlorinator !== 'undefined' ? utils.makeBool(data.useChlorinator) : this.orp.useChlorinator;
                 if (this.orp.useChlorinator) {
-                    if (typeof data.chlorId === 'undefined') {
-                        return Promise.reject(new InvalidEquipmentDataError(`Chlorinator ID must be provided when useChlorinator is true`, 'chemController', data.chlorId));
+                    let chlorId = typeof data.chlorId !== 'undefined' ? data.chlorId : this.orp.chlorId;
+                    if (typeof chlorId === 'undefined') {
+                        return Promise.reject(new InvalidEquipmentDataError(`Chlorinator ID must be provided when useChlorinator is true`, 'chemController', chlorId));
                     }
-                    let chlor = sys.chlorinators.getItemById(data.chlorId);
+                    let chlor = sys.chlorinators.getItemById(chlorId);
                     if (typeof chlor === 'undefined') {
-                        return Promise.reject(new InvalidEquipmentDataError(`Chlorinator with ID ${data.chlorId} not found`, 'chemController', data.chlorId));
+                        return Promise.reject(new InvalidEquipmentDataError(`Chlorinator with ID ${chlorId} not found`, 'chemController', chlorId));
                     }
                     if (chlor.body !== this.chemController.chem.body && chlor.body !== 32) {
-                        return Promise.reject(new InvalidEquipmentDataError(`Chlorinator body does not match the chem controller body`, 'chemController', data.chlorId));
+                        return Promise.reject(new InvalidEquipmentDataError(`Chlorinator body does not match the chem controller body`, 'chemController', chlorId));
                     }
-                    let assignedChemController = sys.chemControllers.get().find((cc: ChemController) => 
+                    let assignedChemController = sys.chemControllers.get().find((cc: ChemController) =>
                         {
-                            return cc.orp.chlorId === data.chlorId && cc.id !== this.chemController.id;
+                            return cc.orp.chlorId === chlorId && cc.id !== this.chemController.id;
                         });
                     if (assignedChemController) {
-                        return Promise.reject(new InvalidEquipmentDataError(`Chlorinator is already assigned to another chem controller`, 'chemController', data.chlorId));
+                        return Promise.reject(new InvalidEquipmentDataError(`Chlorinator is already assigned to another chem controller`, 'chemController', chlorId));
                     }
-                    this.orp.chlorId = data.chlorId;
+                    this.orp.chlorId = chlorId;
                     if (typeof data.chlorDosingMethod !== 'undefined') { this.orp.chlorDosingMethod = data.chlorDosingMethod; }
                 } else {
                     this.orp.chlorId = undefined;


### PR DESCRIPTION
Fixes #1177

## Summary

- `setORPAsync` required `data.chlorId` to be re-supplied on every request when `useChlorinator` is `true`, even when the caller was only changing an unrelated setting (e.g. pH setpoint)
- Added a one-line fallback so `chlorId` resolves from the request or falls back to `this.orp.chlorId`, consistent with how every other field in the same method is handled
- All existing chlorinator validation (body match, duplicate assignment, existence check) still runs against the resolved value

## Change

**`controller/nixie/chemistry/ChemController.ts`**

```typescript
// Before (~line 1977)
if (typeof data.chlorId === 'undefined') {
    return Promise.reject(new InvalidEquipmentDataError(...));
}
let chlor = sys.chlorinators.getItemById(data.chlorId);
// ... all references use data.chlorId

// After
let chlorId = typeof data.chlorId !== 'undefined' ? data.chlorId : this.orp.chlorId;
if (typeof chlorId === 'undefined') {
    return Promise.reject(new InvalidEquipmentDataError(...));
}
let chlor = sys.chlorinators.getItemById(chlorId);
// ... all references use chlorId
```

## Test plan

- [x] Changing pH setpoint via dashboard succeeds with no error
- [x] Changing ORP setpoint via dashboard succeeds with no error  
- [x] `PUT /state/chemController` with `useChlorinator: true` and invalid `chlorId: 999` still rejects correctly
- [x] `PUT /state/chemController` with `useChlorinator: true` and valid `chlorId: 1` succeeds

🤖 Diagnosed and drafted with [Claude Code](https://claude.ai/code) — fix reviewed and verified by me.