### PR TITLE
Chemistry: add optional singleMixPeriod gating

### DIFF
--- a/controller/Equipment.ts
+++ b/controller/Equipment.ts
@@ -2292,6 +2292,7 @@ export class ChemController extends EqItem implements IChemController {
         if (typeof this.data.borates === 'undefined') this.data.borates = 0;
         if (typeof this.data.siCalcType === 'undefined') this.data.siCalcType = 0;
         if (typeof this.data.intellichemStandalone === 'undefined') this.data.intellichemStandalone = false;
+        if (typeof this.data.singleMixPeriod === 'undefined') this.data.singleMixPeriod = false;
         super.initData();
     }
     public dataName = 'chemControllerConfig';
@@ -2327,6 +2328,8 @@ export class ChemController extends EqItem implements IChemController {
     public get lsiRange(): AlarmSetting { return new AlarmSetting(this.data, 'lsiRange', this); }
     public get firmware(): string { return this.data.firmware; }
     public set firmware(val: string) { this.setDataVal('firmware', val); }
+    public get singleMixPeriod(): boolean { return this.data.singleMixPeriod; }
+    public set singleMixPeriod(val: boolean) { this.setDataVal('singleMixPeriod', val); }
     public getExtended() {
         let chem = this.get(true);
         chem.type = sys.board.valueMaps.chemControllerTypes.transform(this.type);
@@ -2364,6 +2367,7 @@ export class ChemDoser extends EqItem implements IChemical {
         if (typeof this.mixingTime === 'undefined') this.data.mixingTime = 3600;
         if (typeof this.data.setpoint === 'undefined') this.data.setpoint = 100;
         if (typeof this.data.type === 'undefined') this.data.type = 0;
+        if (typeof this.data.singleMixPeriod === 'undefined') this.data.singleMixPeriod = false;
         super.initData();
     }
     public get id(): number { return this.data.id; }
@@ -2402,6 +2406,8 @@ export class ChemDoser extends EqItem implements IChemical {
     public get flowSensor(): ChemFlowSensor { return new ChemFlowSensor(this.data, 'flowSensor', this); }
     public get flowOnlyMixing(): boolean { return utils.makeBool(this.data.flowOnlyMixing); }
     public set flowOnlyMixing(val: boolean) { this.setDataVal('flowOnlyMixing', val); }
+    public get singleMixPeriod(): boolean { return this.data.singleMixPeriod; }
+    public set singleMixPeriod(val: boolean) { this.setDataVal('singleMixPeriod', val); }
     public get pump(): ChemicalPump { return new ChemicalPump(this.data, 'pump', this); }
     public get tank(): ChemicalTank { return new ChemicalTank(this.data, 'tank', this); }
     public getExtended() {

--- a/controller/nixie/chemistry/ChemController.ts
+++ b/controller/nixie/chemistry/ChemController.ts
@@ -586,6 +586,7 @@ export class NixieChemController extends NixieChemControllerBase {
                 if (typeof data.lsiRange.low === 'number') chem.lsiRange.low = data.lsiRange.low;
                 if (typeof data.lsiRange.high === 'number') chem.lsiRange.high = data.lsiRange.high;
             }
+            if (typeof data.singleMixPeriod !== 'undefined') chem.singleMixPeriod = utils.makeBool(data.singleMixPeriod);
             if (typeof data.siCalcType !== 'undefined') schem.siCalcType = chem.siCalcType = data.siCalcType;
             await this.flowSensor.setSensorAsync(data.flowSensor);
             // Alright we are down to the equipment items all validation should have been completed by now.
@@ -1794,6 +1795,11 @@ export class NixieChemicalPh extends NixieChemical {
             else if (sph.dailyLimitReached) {
                 await this.cancelDosing(sph, 'daily limit');
             }
+            else if (this.chemController.chem.singleMixPeriod && sph.chemController.orp.dosingStatus === 1) {
+                // Don't dose pH if ORP is mixing - enforce single mixing period (only when enabled)
+                await this.cancelDosing(sph, 'orp mixing');
+                return;
+            }
             else if (status === 'monitoring' || status === 'dosing') {
                 // Figure out what mode we are in and what mode we should be in.
                 //sph.level = 7.61;
@@ -2287,6 +2293,11 @@ export class NixieChemicalORP extends NixieChemical {
             // if the ph pump is dosing and dosePriority is enabled, do not dose
             else if (sorp.chemController.ph.pump.isDosing && chem.ph.dosePriority) {
                 await this.cancelDosing(sorp, 'ph pump dosing + dose priority');
+                return;
+            }
+            else if (chem.singleMixPeriod && sorp.chemController.ph.dosingStatus === 1) {
+                // Don't dose ORP if pH is mixing - enforce single mixing period (only when enabled)
+                await this.cancelDosing(sorp, 'ph mixing');
                 return;
             }
             else if (status === 'monitoring' || status === 'dosing') {

--- a/controller/nixie/chemistry/ChemDoser.ts
+++ b/controller/nixie/chemistry/ChemDoser.ts
@@ -429,6 +429,7 @@ export class NixieChemDoser extends NixieChemDoserBase implements INixieChemical
                     (typeof data.mixingTimeSeconds !== 'undefined' ? parseInt(data.mixingTimeSeconds, 10) : 0);
             }
             chem.mixingTime = typeof data.mixingTime !== 'undefined' ? parseInt(data.mixingTime, 10) : chem.mixingTime;
+            if (typeof data.singleMixPeriod !== 'undefined') chem.singleMixPeriod = utils.makeBool(data.singleMixPeriod);
             await this.flowSensor.setSensorAsync(data.flowSensor);
             await this.tank.setTankAsync(schem.tank, data.tank);
             await this.pump.setPumpAsync(schem.pump, data.pump);
@@ -586,6 +587,22 @@ export class NixieChemDoser extends NixieChemDoserBase implements INixieChemical
                 await this.cancelDosing(sd, 'daily limit');
             }
             else if (status === 'monitoring' || status === 'dosing') {
+                // Check if any other chem doser is currently mixing - only if singleMixPeriod is enabled
+                if (this.chem.singleMixPeriod) {
+                    let otherDoserMixing = false;
+                    for (let i = 0; i < state.chemDosers.length; i++) {
+                        let otherDoser = state.chemDosers.getItemByIndex(i);
+                        if (otherDoser.id !== sd.id && otherDoser.dosingStatus === 1) { // 1 is mixing
+                            logger.info(`Cannot dose ${sd.chemType} - ${otherDoser.chemType} doser is currently mixing`);
+                            otherDoserMixing = true;
+                            break;
+                        }
+                    }
+                    if (otherDoserMixing) {
+                        await this.cancelDosing(sd, 'another doser mixing');
+                        return;
+                    }
+                }
                 // Figure out what mode we are in and what mode we should be in.
                 //sph.level = 7.61;
                 // Check the setpoint and the current level to see if we need to dose.


### PR DESCRIPTION
## Summary
- Add optional singleMixPeriod setting for chemistry controllers/dosers
- Enforce single active mixing period when enabled
- Keep default behavior unchanged (alse)

## Scope
- controller/Equipment.ts
- controller/nixie/chemistry/ChemController.ts
- controller/nixie/chemistry/ChemDoser.ts

## Notes
- This PR intentionally excludes pump communication and rewind logic changes.
- Build verified with 
pm run build.