### PR TITLE
Pump: fix no-op catch in Hayward remote control handler

### DIFF
--- a/controller/nixie/pumps/Pump.ts
+++ b/controller/nixie/pumps/Pump.ts
@@ -958,7 +958,7 @@ export class NixiePumpHWVS extends NixiePumpRS485 {
                     }
                 }
             }
-        } catch(err) { `Error sending setPumpToRemoteControl message for ${this.pump.name}: ${err.message}` };
+        } catch(err) { logger.error(`Error sending setPumpToRemoteControl message for ${this.pump.name}: ${err.message}`); };
     }
     protected async setPumpRPMAsync() {
         // Address 1


### PR DESCRIPTION
## Summary
- Replace no-op string expression in catch block with logger.error(...)
- No behavior changes outside logging path

## Scope
- controller/nixie/pumps/Pump.ts (single-line fix)

## Notes
- This PR intentionally excludes retries/backoff/telemetry handling and package-lock changes.
- Build verified with 
pm run build.