### PR TITLE
Fix schedule yesterday-branch endTime typo (closes #1190)

### DIFF
--- a/controller/State.ts
+++ b/controller/State.ts
@@ -1309,7 +1309,7 @@ export class ScheduleTime extends ChildEqState {
                 let sd = schedDays.find(elem => elem.dow === ytimes.startTime.getDay());
                 if (typeof sd !== 'undefined' && (sched.scheduleDays & sd.bitval) !== 0) {
                     times.startTime = ytimes.startTime;
-                    times.endTime = ytimes.startTime;
+                    times.endTime = ytimes.endTime;
                     return times;
                 }
             }


### PR DESCRIPTION
## Summary

- Fix `controller/State.ts:1312` — the "still running from yesterday" branch of `ScheduleTime.calcScheduleDate` was assigning `times.endTime = ytimes.startTime` instead of `ytimes.endTime`.

That single typo collapsed the synthesized live window to a zero-duration point in the past, which made `_calcShouldBeOn` return `false` whenever a schedule's window crossed local midnight and the current time was before today's `ttimes.startTime`.

The today-branch (line 1301: `times.endTime = ttimes.endTime`) and tomorrow-branch (line 1331: `times.endTime = ntimes.endTime`) were already correct; only the yesterday-branch was wrong. The fix copies that pattern.

## Reference issue

Closes #1190 — full trace is in the issue. Short version: a `12:00 PM → 12:00 PM` schedule shows greyed/inactive in dashPanel from midnight until noon on the following day, because every AM evaluation lands in the yesterday-branch and gets the broken endTime back.

## Test plan

- [x] `tsc --noEmit` passes (baseline was clean, diff still clean).
- [ ] Manual: configure a single schedule `12:00 PM → 12:00 PM` on a feature, wait through midnight, confirm dashPanel shows it active in the AM hours of the following day.
- [ ] Manual: configure two overlapping schedules (e.g. `12:00 AM → 12:00 AM` and `12:00 PM → 12:00 PM`) on the same circuit and confirm both show active in their respective windows after a midnight rollover.

## Risk

Localized to a single line in a branch that was already returning a degenerate window. No callers depend on the old (broken) value.