### PR TITLE
fix: add web/bindings files to Dockerfile so that connections work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN mkdir -p /app/logs /app/data /app/backups /app/web/bindings/custom \
 COPY --chown=node:node --from=build /app/package*.json ./
 COPY --chown=node:node --from=build /app/node_modules ./node_modules
 COPY --chown=node:node --from=build /app/dist ./dist
+COPY --chown=node:node --from=build /app/web/bindings ./web/bindings
 COPY --chown=node:node --from=build /app/defaultConfig.json ./defaultConfig.json
 COPY --chown=node:node --from=build /app/config.json ./config.json
 COPY --chown=node:node --from=build /app/README.md ./README.md


### PR DESCRIPTION
When using the current docker image, /app/web/bindings is created but empty. This prevents any bindings that rely on a JSON file (MQTT, Home Assistant, etc.) from functioning. This one-line change copies in just the binding files from the build container so that that functionality will work.

Fixes #1201.