### PR TITLE
fix(comms): preserve screenlogic config on RS-485 port writes

### DIFF
--- a/controller/comms/Comms.ts
+++ b/controller/comms/Comms.ts
@@ -97,7 +97,12 @@ export class Connection {
                 netPort: 9801,
                 inactivityRetry: 10
             });
-            if (portId === 0) {
+            // Seed only when absent.  This ran unconditionally, so every write
+            // to this endpoint for port 0 wiped an existing screenlogic block --
+            // password included -- and it is only restored from the request when
+            // the port type is 'screenlogic'.  Same guard as the cfg.screenlogic
+            // initialiser further down.
+            if (portId === 0 && !pdata.screenlogic) {
                 pdata.screenlogic = {
                     connectionType: "local",
                     systemName: "Pentair: 00-00-00",


### PR DESCRIPTION
Fixes #1236.

`setPortAsync` reset `pdata.screenlogic` to defaults for `portId === 0` before reading anything from the request, and the only place it is written back from the body is guarded by `pdata.type === 'screenlogic'`. On a `local` RS-485 port that branch never runs, so **every** `PUT /app/rs485Port` erased `screenlogic.password` and reset `systemName`, regardless of what the caller sent. Nothing in the response or the log said so.

The fix is to seed the block only when it is absent — which is the form the `cfg.screenlogic` initialiser already uses about ninety lines further down in the same function:

```ts
if (portId === 0 && !cfg.screenlogic) { ... }
```

so this makes the two consistent rather than introducing a new convention.

### Verified

- `npx tsc --noEmit` clean, against v10.0.1 on a Raspberry Pi 4B.
- Before the change, on that box: `PUT /app/rs485Port` echoing the whole comms object with only `enabled` flipped took `screenlogic.password` from `1234` to `""`. Observed twice — the other time while moving `rs485Port` from `/dev/ttyUSB0` to `/dev/serial0`.

### No test, and why

`test/integration` is a comparison harness that boots njsPC against a live OCP over WebSocket and diffs the two, so it is not somewhere a `setPortAsync` regression fits, and I have no OCP to run it against. A unit test for this would mean adding a second, non-integration vitest project, which felt like the wrong thing to introduce uninvited on a first PR. Happy to add one in whatever shape you would prefer.

### Scope

One guard, one comment. I have not audited whether other `config.getSection` consumers reset sibling blocks the same way — worth a look, but not something I can test broadly.
